### PR TITLE
ci: add zizmor GitHub Actions security analysis workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0


### PR DESCRIPTION
Adds a pinned zizmor workflow to audit GitHub Actions security posture on pull requests and default-branch pushes.\n\nSecurity defaults included:\n- top-level permissions: {}\n- checkout with persist-credentials: false\n- pinned action SHAs for checkout + zizmor action\n\nThis helps prevent reintroducing risky workflow patterns (including unsafe pull_request_target usage).